### PR TITLE
Switch to pywinctl

### DIFF
--- a/Code/Python/full_GUI.py
+++ b/Code/Python/full_GUI.py
@@ -1,4 +1,3 @@
-from imaplib import Commands
 from tkinter import *
 from tkinter import ttk
 from tkinter import filedialog
@@ -14,7 +13,7 @@ import time
 
 import pickle
 
-import pygetwindow as gw #for window switching (windows only)
+import pywinctl as gw # hopefully sufficient support for win, macos, and linux
 
 import numpy as np
 import cv2
@@ -83,7 +82,7 @@ app_dict = {
 }
  
 app = customtkinter.CTk()
-app.geometry("800x900")
+app.geometry("800x1200")
 app.title("Macro Keyboard Configure")
 
 
@@ -119,12 +118,13 @@ def updatePorts():
             ser = serial.Serial(portSelect.get(), baudSelect.get())  #let user choose in future
             ser.timeout = 0.5
             connectLabel.configure(text="Connected", text_color="green")
-        except:
+        except Exception as e:
+            print(e)
             connectLabel.configure(text="Not Connected", text_color="red")
 
 def detectPort(ports):
     for port, desc, hwid in sorted(ports):
-        if ("USB-SERIAL CH340" in desc):
+        if ("USB-SERIAL CH340" in desc or hwid.startswith("USB VID:PID=1A86:7523")):
             print("Auto Detect:")
             print(port)
             portSelect.set(port)
@@ -228,7 +228,7 @@ def macro_record():
 
 def connectSwitchChange():
     if (connectSwitch.get() =="on"):
-        detectPort()
+        detectPort(serial.tools.list_ports.comports())
     switchChange()
 
 def switchChange():


### PR DESCRIPTION
## Summary

* I managed to get your Python code running on my Manjaro Linux box by switching to a fork of `pygetwindow`.  (I suspect the author of the fork had a similar frustration with `pygetwindow` being Win32 only.)
* Added the USB VID:PID string to the ports matcher.

## Miscellaneous

* Remove unused lib, `imaplib`.
* Printe out exception when connecting to matched serial port.  This was useful to me when I realized my user wasn't in the correct group for permission to use the serial ports.
* Increase window height.  (This probably can be made dynamic.)